### PR TITLE
Replace dfs.ItemInfo.Count with len(dfs.ItemInfo)

### DIFF
--- a/pydhi/dfs0.py
+++ b/pydhi/dfs0.py
@@ -22,7 +22,7 @@ class dfs0():
 
         dfs = DfsFileFactory.DfsGenericOpen(dfs0file)
 
-        n_items = dfs.ItemInfo.Count
+        n_items = len(dfs.ItemInfo)
         nt = dfs.FileInfo.TimeAxis.NumberOfTimeSteps
 
         names = []

--- a/pydhi/dfs0.py
+++ b/pydhi/dfs0.py
@@ -11,6 +11,8 @@ from DHI.Generic.MikeZero.DFS.dfs0 import Dfs0Util
 from System.Runtime.InteropServices import GCHandle, GCHandleType
 import ctypes
 
+from pydhi.helpers import safe_length
+
 
 class dfs0():
 
@@ -22,7 +24,7 @@ class dfs0():
 
         dfs = DfsFileFactory.DfsGenericOpen(dfs0file)
 
-        n_items = len(dfs.ItemInfo)
+        n_items = safe_length
         nt = dfs.FileInfo.TimeAxis.NumberOfTimeSteps
 
         names = []

--- a/pydhi/dfs0.py
+++ b/pydhi/dfs0.py
@@ -24,7 +24,7 @@ class dfs0():
 
         dfs = DfsFileFactory.DfsGenericOpen(dfs0file)
 
-        n_items = safe_length
+        n_items = safe_length(dfs.ItemInfo)
         nt = dfs.FileInfo.TimeAxis.NumberOfTimeSteps
 
         names = []

--- a/pydhi/helpers.py
+++ b/pydhi/helpers.py
@@ -1,0 +1,14 @@
+def safe_length(input_list):
+    """
+    Get the length of a Python or C# list.
+
+    Usage:
+       safe_length(input_list)
+
+    input_list : Python or C# list
+
+    Return:
+        int
+           Integer giving the length of the input list.
+    """
+    return getattr(input_list, 'Count', len(input_list))


### PR DESCRIPTION
In Python 3.7, dfs.ItemInfo.Count raised an error that using len instead
fixes so that code reads a dfs0 file successfully.